### PR TITLE
Ignore only apikey.txt file instead of ignoring all .txt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-*.txt
+
+# secrets
+apikey.txt
+.env
+config.env 


### PR DESCRIPTION
#### *.txt  - ignores all .txt files inside the project, because of which `requirements.txt` file cannot be added to git. Instead ignore only `apiKey.txt` file.

#### It is recommended to use `dotenv` files to hide secrets.

#### Files changed
- `.gitignore`